### PR TITLE
Tile counts for choose game buttons

### DIFF
--- a/Assets/Scripts/ChooseGameboard.cs
+++ b/Assets/Scripts/ChooseGameboard.cs
@@ -5,9 +5,19 @@ using System.IO;
 using TMPro;
 using UnityEditor.Build.Content;
 using UnityEngine.UI;
+using System;
 
 public class ChooseGameboard : MonoBehaviour
 {
+    public GameObject buttonContentHolder, buttonTemplate;
+
+    // Awake is called before Start
+    void Awake()
+    {
+        List<string> fileList = ProcessFiles();
+        GenerateButtons(buttonContentHolder, fileList);
+    }
+    
     List<string> ProcessFiles()
     {
         string sourceDir = Application.dataPath + "/Boards/";
@@ -18,8 +28,10 @@ public class ChooseGameboard : MonoBehaviour
             if (file.EndsWith(".json", true, null))
             {
                 string name = file.Substring(sourceDir.Length, (file.Length - sourceDir.Length) - 5);
+                int linesInFile = File.ReadAllLines(file).Length;
+                int tileCount = (int) (linesInFile * 0.1666667 - 0.6666667);
                 string lastModified = File.GetLastWriteTime(file).ToString("MM/dd/yy HH:mm");
-                string gameInfo = name + " \t " + lastModified;
+                string gameInfo = name + "  " + tileCount + " tiles  " + lastModified;
                 result.Add(gameInfo);
                 Debug.Log(gameInfo);
             }
@@ -27,38 +39,21 @@ public class ChooseGameboard : MonoBehaviour
         return result;
     }
 
-    public GameObject buttonContentHolder, buttonTemplate;
-    // [SerializeField] private GameObject buttonTemplate;
+    
     void GenerateButtons(GameObject buttonContentHolder, List<string> files)
     {
-        // TODO:  https://www.youtube.com/watch?v=2TYLBusJKjc
+        // Button generation based on https://www.youtube.com/watch?v=2TYLBusJKjc
         foreach (string file in files)
         {
+            // Prevent button creation for the _New (Blank) board if the user wants to play a game b/c the blank board is unplayable.
+            if (StateNameController.clickedButtonText.ToLower() == "play" && file.Contains("_New (Blank)")) {
+                continue;
+            }
             GameObject button = Instantiate(buttonTemplate) as GameObject;
             button.SetActive(true);
             button.GetComponentInChildren<TextMeshProUGUI>().text = file;
             button.transform.SetParent(buttonTemplate.transform.parent, false);
         }
-        
-    }
-    
-
-    // Awake is called before Start
-    void Awake()
-    {
-        List<string> fileList = ProcessFiles();
-        GenerateButtons(buttonContentHolder, fileList);
-    }
-    
-    // Start is called before the first frame update
-    void Start()
-    {
-        
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
         
     }
 }


### PR DESCRIPTION
Provides the tile count for the various game boards that are available for playing and editing.

Does not allow the button for the _New (Blank) board to be loaded if the user has selected "Play" from the main menu.  This ensures that only a playable board can be loaded.