### PR TITLE
Fix applied to ButtonListButton

### DIFF
--- a/Assets/Scripts/ButtonListButton.cs
+++ b/Assets/Scripts/ButtonListButton.cs
@@ -12,8 +12,7 @@ public class ButtonListButton : MonoBehaviour
     public void LoadSceneByName()
     {
         string buttonText = GetComponentInChildren<TextMeshProUGUI>().text;
-        Debug.Log("The button text is " + buttonText);
-        int tabPos = buttonText.IndexOf('\t') - 1;
+        int tabPos = buttonText.IndexOf("  ");
         string fileName = buttonText[..tabPos] + ".json";
         string folder = Application.dataPath + "/Boards/";
         string filePath = folder + fileName;
@@ -26,15 +25,5 @@ public class ButtonListButton : MonoBehaviour
         }
         
     }
-    // Start is called before the first frame update
-    void Start()
-    {
-        
-    }
 
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
 }


### PR DESCRIPTION
Applied fix to ButtonListButton - double spaces are used to separate the file names rather than tabs so everything will fit on the button.  Needed to update the separator from \t to "  " so the file name would be pulled correctly.